### PR TITLE
Add initial code for syntax highlighting

### DIFF
--- a/client/src/CodeInput.js
+++ b/client/src/CodeInput.js
@@ -7,32 +7,46 @@ import 'codemirror/theme/material.css';
 require('codemirror/mode/rust/rust');
 require('codemirror/mode/clike/clike')
 
-const CodeInput = () => {
-    return (
-        <div className="ui card">
-            <div className="content">
-                <h2 className="ui teal header">Code Input</h2>
-                <LanguageSelection />
-                <FileUpload />
-            </div>
-            <CodeMirror
-                options={{
-                    mode: 'clike',
-                    theme: 'material',
-                    lineNumbers: true,
-                    value: 'hello'
-                }}
-                onChange={(editor, data, value) => {
-                }}
-            />
-            <div className="extra content">
-                <div className="ui two buttons">
-                    <div className="ui basic yellow button">Reset Code</div>
-                    <div className="ui basic olive button">Run</div>
+class CodeInput extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {lang: 'clike'};
+
+        this.toggleLanguage = this.toggleLanguage.bind(this);
+    }
+
+    toggleLanguage(newLang) {
+        console.log("Toggling language...")
+        this.setState({lang: newLang});
+    }
+
+    render() {
+        return (
+            <div className="ui card">
+                <div className="content">
+                    <h2 className="ui teal header">Code Input</h2>
+                    <LanguageSelection changeLang={this.toggleLanguage}/>
+                    <FileUpload />
+                </div>
+                <CodeMirror
+                    options={{
+                        mode: this.state.lang,
+                        theme: 'material',
+                        lineNumbers: true,
+                        value: 'hello'
+                    }}
+                    onChange={(editor, data, value) => {
+                    }}
+                />
+                <div className="extra content">
+                    <div className="ui two buttons">
+                        <div className="ui basic yellow button">Reset Code</div>
+                        <div className="ui basic olive button">Run</div>
+                    </div>
                 </div>
             </div>
-        </div>
-    );
+        );
+    }
 };
 
 export default CodeInput;

--- a/client/src/LanguageSelection.js
+++ b/client/src/LanguageSelection.js
@@ -1,19 +1,58 @@
-const LanguageSelection = () => {
-    return (
-        <div className="ui container">
-            <div className="content">
-                <h3 className="ui green header">Language Selection</h3>
+import React from "react";
+
+class LanguageSelection extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            language: ""
+        }
+
+        this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(event) {
+        console.log(event.target.value); 
+        if (event.target.value === "0") {
+            this.setState({
+                language: "c" 
+            }, () => {
+                console.log(this.state.language);
+            });
+            this.props.changeLang("clik");
+        } else if (event.target.value === "1") {
+            this.setState({
+                language: "c++" 
+            }, () => {
+                console.log(this.state.language);
+            });
+            this.props.changeLang("clike");
+        } else if (event.target.value === "2") {
+            this.setState({
+                language: "rust" 
+            }, () => {
+                console.log(this.state.language);
+            });
+            this.props.changeLang("rust");
+        }  
+    }
+
+    render () {
+        return (
+            <div className="ui container">
+                <div className="content">
+                    <h3 className="ui green header">Language Selection</h3>
+                </div>
+                <div className="content">
+                    <select className="ui fluid dropdown" onChange={this.handleChange}>
+                        <option value="">Language...</option>
+                        <option value="0">C</option>
+                        <option value="1">C++</option>
+                        <option value="2">Rust</option>
+                    </select>
+                </div>
             </div>
-            <div className="content">
-                <select className="ui fluid dropdown">
-                    <option value="">Language</option>
-                    <option value="2">C</option>
-                    <option value="1">C++</option>
-                    <option value="0">Rust</option>
-                </select>
-            </div>
-        </div>
-    );
-};
+        );
+    }
+}
 
 export default LanguageSelection;

--- a/client/src/LanguageSelection.js
+++ b/client/src/LanguageSelection.js
@@ -18,7 +18,7 @@ class LanguageSelection extends React.Component {
             }, () => {
                 console.log(this.state.language);
             });
-            this.props.changeLang("clik");
+            this.props.changeLang("clike");
         } else if (event.target.value === "1") {
             this.setState({
                 language: "c++" 


### PR DESCRIPTION
Here is my initial code for getting the syntax highlighting to change. In Chrome, I could get things to work properly to and from Rust. The clike highlighting did not look as expected. However, I wonder if that's something with CodeMirror because the code updates the values properly.

I had to change the two components I altered to stateful components in order to share and manage the state for syntax highlighting in CodeInput and for the current language in LanguageSelection, which will also be useful when we need to send different compiling lines to the server.

Please test this out, and let me know what you think. It's not a ton, but it took me a long time to debug and figure out the stuff with state and when and how to re-render on state updates. Also, I had some weird bugs in Firefox when trying to print to the console, but Chrome looked as expected. Thanks, team!